### PR TITLE
Remove Id to fill array

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -33,7 +33,6 @@ class Entry extends FileEntry
         }
 
         return $class::findOrNew($this->id())->fill([
-            'id' => $this->id(),
             'origin_id' => $this->originId(),
             'site' => $this->locale(),
             'slug' => $this->slug(),


### PR DESCRIPTION
I removed the Id attribute from the array on the findOrNew method because unnecessary and it was causing an SQL error on Postgresql.